### PR TITLE
Don't recommend running the Go compiler as root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ go get -u -v github.com/raphaelreyna/oneshot
 ```bash
 git clone github.com/raphaelreyna/oneshot
 cd oneshot
+make
 sudo make install
 ```
 


### PR DESCRIPTION
Running `sudo make install` without running `make` first will run the Go
compiler (which ever so often has arbitrary command execution CVEs) with
root privileges, which isn't necessary. The only step that has to run as
root is specifically the installation one.