### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ $ oneshot -u | gofmt | oneshot -J
 ```
 The `-J` flag we are using here tells oneshot to only start serving HTTP once it has received an EOF from its stdin.
 This allows us to create unix pipelines without needing to specify a different port for each instance of oneshot.
-In this scenario, the user would upload or type in some Go code and upon hitting the back button (refresh wont work !) or going back to the original URL, the user will receive their formatted Go code.
+In this scenario, the user would upload or type in some Go code and upon hitting the back button (refresh won't work !) or going back to the original URL, the user will receive their formatted Go code.
 
 
 

--- a/cmd/conf/flags.go
+++ b/cmd/conf/flags.go
@@ -11,7 +11,7 @@ func (c *Conf) SetFlags(cmd *cobra.Command) {
 
 	flags.BoolVarP(&versionFlag, "version", "v", false, `Version and other info.`)
 
-	flags.BoolVarP(&c.ExitOnFail, "exit-on-fail", "F", false, `Exit as soon as client disconnects regardless if file was transferred succesfully.
+	flags.BoolVarP(&c.ExitOnFail, "exit-on-fail", "F", false, `Exit as soon as client disconnects regardless if file was transferred successfully.
 By default, oneshot will exit once the client has downloaded the entire file.
 If using authentication, setting this flag will cause oneshot to exit if client provides wrong / no credentials.
 If set, once the first client connects, all others will receive a 410 Gone status immediately;
@@ -218,7 +218,7 @@ See also: -u, --upload; --upload-input; --no-csrf-token`,
 	)
 
 	flags.StringVar(&c.UploadHTML, "upload-html", "", `Path to html file to present to clients attempting to upload.
-The file may be a Go HTML temlate. Two boolean values '.FileSection' and '.InputSection' and a string value ' .CSRFToken ' are made available to the template.
+The file may be a Go HTML template. Two boolean values '.FileSection' and '.InputSection' and a string value ' .CSRFToken ' are made available to the template.
 The boolean values ' .FileSection ' and ' .InputSection ' reflect the usage of the -u, --upload; --upload-input and --upload-file flags.
 The string value ' .CSRFToken ' reflects the usage of the --no-csrf-token and --custom-csrf-token flags.
 This flag does nothing if none of the -u, --upload, --upload-input or --upload-file flags are set.

--- a/doc/md/3_examples.md
+++ b/doc/md/3_examples.md
@@ -65,5 +65,5 @@ $ oneshot -u | gofmt | oneshot -J
 ```
 The `-J` flag we are using here tells oneshot to only start serving HTTP once it has received an EOF from its stdin.
 This allows us to create unix pipelines without needing to specify a different port for each instance of oneshot.
-In this scenario, the user would upload or type in some Go code and upon hitting the back button (refresh wont work !) or going back to the original URL, the user will receive their formatted Go code.
+In this scenario, the user would upload or type in some Go code and upon hitting the back button (refresh won't work !) or going back to the original URL, the user will receive their formatted Go code.
 

--- a/internal/handlers/upload.go
+++ b/internal/handlers/upload.go
@@ -279,7 +279,7 @@ func HandleUpload(file *file.FileWriter, unixEOLNormalization bool, csrfToken st
 				return err
 			}
 
-			// If we havent found the CSRF token yet, look for it in the parsed form data
+			// If we haven't found the CSRF token yet, look for it in the parsed form data
 			if !foundCSRFToken && r.PostFormValue("csrf-token") != csrfToken {
 				err := errors.New("invalid CSRF token")
 				http.Error(w, err.Error(), http.StatusUnauthorized)

--- a/oneshot.1
+++ b/oneshot.1
@@ -74,7 +74,7 @@ See also: \-c, \-\-cgi ; \-C, \-\-cgi\-strict ; \-s, \-\-shell\-command ; \-S, \
 
 .PP
 \fB\-F\fP, \fB\-\-exit\-on\-fail\fP[=false]
-	Exit as soon as client disconnects regardless if file was transferred succesfully.
+	Exit as soon as client disconnects regardless if file was transferred successfully.
 By default, oneshot will exit once the client has downloaded the entire file.
 If using authentication, setting this flag will cause oneshot to exit if client provides wrong / no credentials.
 If set, once the first client connects, all others will receive a 410 Gone status immediately;
@@ -258,7 +258,7 @@ See also: \-\-upload\-input; \-u, \-\-upload
 .PP
 \fB\-\-upload\-html\fP=""
 	Path to html file to present to clients attempting to upload.
-The file may be a Go HTML temlate. Two boolean values '.FileSection' and '.InputSection' and a string value ' .CSRFToken ' are made available to the template.
+The file may be a Go HTML template. Two boolean values '.FileSection' and '.InputSection' and a string value ' .CSRFToken ' are made available to the template.
 The boolean values ' .FileSection ' and ' .InputSection ' reflect the usage of the \-u, \-\-upload; \-\-upload\-input and \-\-upload\-file flags.
 The string value ' .CSRFToken ' reflects the usage of the \-\-no\-csrf\-token and \-\-custom\-csrf\-token flags.
 This flag does nothing if none of the \-u, \-\-upload, \-\-upload\-input or \-\-upload\-file flags are set.

--- a/release
+++ b/release
@@ -16,7 +16,7 @@ make oneshot.1
 git add oneshot.1
 
 function updateVersion {
-	read -p "new version (curently at ${CURRENT_VERSION}): " NEW_VERSION
+	read -p "new version (currently at ${CURRENT_VERSION}): " NEW_VERSION
 	## Make sure new version has valid format
 	if [[ $NEW_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
 	then

--- a/v2/README.md
+++ b/v2/README.md
@@ -81,7 +81,7 @@ $ oneshot -u | gofmt | oneshot -J
 ```
 The `-J` flag we are using here tells oneshot to only start serving HTTP once it has received an EOF from its stdin.
 This allows us to create unix pipelines without needing to specify a different port for each instance of oneshot.
-In this scenario, the user would upload or type in some Go code and upon hitting the back button (refresh wont work !) or going back to the original URL, the user will receive their formatted Go code.
+In this scenario, the user would upload or type in some Go code and upon hitting the back button (refresh won't work !) or going back to the original URL, the user will receive their formatted Go code.
 
 ### Reporting Bugs, Feature Requests & Contributing
 Please report any bugs or issues [here](https://github.com/forestnode-io/oneshot/issues).

--- a/v2/pkg/commands/discovery-server/handleHTTP.go
+++ b/v2/pkg/commands/discovery-server/handleHTTP.go
@@ -199,7 +199,7 @@ func (s *server) handleAcceptJSON_GET(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// verify the token algorithm hasnt been changed
+	// verify the token algorithm hasn't been changed
 	if token.Method != jwt.SigningMethodHS256 {
 		log.Warn().
 			Str("alg", fmt.Sprintf("%v", token.Header["alg"])).

--- a/v2/pkg/commands/p2p/client/discovery/discoveryServerNegotiation.go
+++ b/v2/pkg/commands/p2p/client/discovery/discoveryServerNegotiation.go
@@ -16,7 +16,7 @@ func NegotiateOfferRequest(ctx context.Context, url, username, password string, 
 	// perform the first request which saves our spot in the queue.
 	// we're going to use the same pathways as browser clients to we
 	// set the accept header to text/http and the user agent to oneshot.
-	// the server will respond differently based on the user agent, it wont send html.
+	// the server will respond differently based on the user agent, it won't send html.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create token request: %w", err)

--- a/v2/pkg/commands/p2p/client/send/cobra.go
+++ b/v2/pkg/commands/p2p/client/send/cobra.go
@@ -236,7 +236,7 @@ func (c *Cmd) send(cmd *cobra.Command, args []string) error {
 	preferredAddress, preferredPort := oneshotnet.PreferNonPrivateIP(transport.PeerAddresses())
 
 	// We need to provide a host header to the request but
-	// it doesnt influence anything in this case since the custom webrtc transport ignores it.
+	// it doesn't influence anything in this case since the custom webrtc transport ignores it.
 	host := "http://localhost:8080"
 	if preferredAddress != "" {
 		host = net.JoinHostPort(preferredAddress, preferredPort)

--- a/v2/pkg/commands/receive/cobra.go
+++ b/v2/pkg/commands/receive/cobra.go
@@ -246,7 +246,7 @@ func (c *Cmd) readCloserFromMultipartFormData(r *http.Request) (*requestBody, er
 	clientProvidedName := fileName(cd)
 
 	contentLength, _ := strconv.ParseInt(part.Header.Get("Content-Length"), 10, 64)
-	// if we couldnt get the content length from a Content-Length header
+	// if we couldn't get the content length from a Content-Length header
 	if contentLength == 0 {
 		// try to get it from our own injected header
 		if mpLengthsString := r.Header.Get("X-Oneshot-Multipart-Content-Lengths"); mpLengthsString != "" {
@@ -296,7 +296,7 @@ func (c *Cmd) readCloserFromApplicationWWWForm(r *http.Request) (*requestBody, e
 		}
 	}
 
-	// If we havent found the CSRF token yet, look for it in the parsed form data
+	// If we haven't found the CSRF token yet, look for it in the parsed form data
 	if !foundCSRFToken && r.PostFormValue("csrf-token") != csrfToken {
 		return nil, &httpError{
 			error: errors.New("invalid CSRF token"),

--- a/v2/pkg/commands/receive/serve.go
+++ b/v2/pkg/commands/receive/serve.go
@@ -45,7 +45,7 @@ func (c *Cmd) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.Contains(rct, "multipart/form-data"): // User uploaded a file
 		rb, err = c.readCloserFromMultipartFormData(r)
-	case r.Header.Get("Content-Length") != "0": // this usually means theres a non-empty body, lets grab it
+	case r.Header.Get("Content-Length") != "0": // this usually means there's a non-empty body, lets grab it
 		rb, err = c.readCloserFromRawBody(r)
 	case strings.Contains(rct, "application/x-www-form-urlencoded"): // User uploaded text from HTML text box
 		rb, err = c.readCloserFromApplicationWWWForm(r)

--- a/v2/pkg/commands/send/serve.go
+++ b/v2/pkg/commands/send/serve.go
@@ -24,7 +24,7 @@ func (c *Cmd) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	go func() {
 		// Read body into the void since this will trigger a
-		// a buffer on the body which can then be inlcuded in the
+		// a buffer on the body which can then be included in the
 		// json report
 		defer close(doneReadingBody)
 		defer r.Body.Close()

--- a/v2/pkg/events/file.go
+++ b/v2/pkg/events/file.go
@@ -19,7 +19,7 @@ type File struct {
 	Size int64 `json:",omitempty"`
 
 	// TransferSize is the total size oneshot has read in / out.
-	// For a succesfull file transfer, this will be equal to the size of the file.
+	// For a successful file transfer, this will be equal to the size of the file.
 	TransferSize      int64         `json:",omitempty"`
 	TransferStartTime time.Time     `json:",omitempty"`
 	TransferEndTime   time.Time     `json:",omitempty"`
@@ -31,7 +31,7 @@ type File struct {
 }
 
 // ComputeTransferFields handles calculating field values that could not be
-// obtained until after the transfer (succesfull or not), such as the duration.
+// obtained until after the transfer (successful or not), such as the duration.
 func (f *File) ComputeTransferFields() {
 	if f == nil {
 		return

--- a/v2/pkg/file/reader.go
+++ b/v2/pkg/file/reader.go
@@ -129,7 +129,7 @@ func NewReadTransferConfig(archiveFormat string, locations ...string) (ReadTrans
 			}
 		}
 	default: // transferring multiple paths
-		// doesnt matter if each one is a file or a dir, archive them all into a single file
+		// doesn't matter if each one is a file or a dir, archive them all into a single file
 		for _, location := range locations {
 			if err := isReadable(location); err != nil {
 				return nil, err

--- a/v2/pkg/file/writer.go
+++ b/v2/pkg/file/writer.go
@@ -29,7 +29,7 @@ func NewWriteTransferConfig(ctx context.Context, location string) (*WriteTransfe
 		// and are outputting json
 		if format, _ := output.GetFormatAndOpts(ctx); format == "json" {
 			// send the contents into the ether.
-			// theres a buffer elsewhere that will provide the contents in the json object.
+			// there's a buffer elsewhere that will provide the contents in the json object.
 			wtc.w = null{}
 		} else {
 			// otherwise write the content to stdout
@@ -46,14 +46,14 @@ func NewWriteTransferConfig(ctx context.Context, location string) (*WriteTransfe
 
 	// get info on user provided location
 	stat, err := os.Stat(location)
-	// if location doesnt exist
+	// if location doesn't exist
 	if err != nil {
-		// then the user wants to receive to a file that doesnt exist yet and has given
+		// then the user wants to receive to a file that doesn't exist yet and has given
 		// us the file and directory names all in 1 string
 		wtc.dir, wtc.userProvidedName = filepath.Split(location)
 	} else {
 		// otherwise, the user either wants to receive to an existing directory and
-		// hasnt given us the name of the file they want to receive to
+		// hasn't given us the name of the file they want to receive to
 		if stat.IsDir() {
 			// so we can only set the directory name
 			wtc.dir = location

--- a/v2/pkg/net/http/middleware.go
+++ b/v2/pkg/net/http/middleware.go
@@ -124,7 +124,7 @@ func MiddlewareShim(mw func(http.Handler) http.Handler) Middleware {
 }
 
 // BlockPrefetch blocks prefetching of the page by reloading the page with a short-lived cookie
-// thats only set if the page is visible. This is to prevent browsers and bots from prefetching.
+// that's only set if the page is visible. This is to prevent browsers and bots from prefetching.
 // Some have recently started not marking the request as a prefetch, so this is a last resort.
 func BlockPrefetch(userAgentKeys ...string) Middleware {
 	bpCookieName := "block-prefetch"

--- a/v2/pkg/net/webrtc/server/httpResponseWriter.go
+++ b/v2/pkg/net/webrtc/server/httpResponseWriter.go
@@ -89,7 +89,7 @@ func (w *ResponseWriter) Flush() error {
 	}
 
 	if w.wroteCount == 0 {
-		// if we havent written anything, send an empty binary message before the EOF
+		// if we haven't written anything, send an empty binary message before the EOF
 		_, err = w.channel.WriteDataChannel([]byte(""), false)
 		if err != nil {
 			return fmt.Errorf("unable to send empty binary message: %w", err)

--- a/v2/pkg/net/webrtc/signallingserver/discoveryServer.go
+++ b/v2/pkg/net/webrtc/signallingserver/discoveryServer.go
@@ -69,7 +69,7 @@ func WithDiscoveryServer(ctx context.Context) (context.Context, <-chan struct{})
 }
 
 // ConnectToDiscoveryServer connects to the discovery server and sends a handshake.
-// The connnection is kept open and stuffed into the context.
+// The connection is kept open and stuffed into the context.
 func ConnectToDiscoveryServer(ctx context.Context, c DiscoveryServerConfig) error {
 	dds, ok := ctx.Value(discoveryServerKey{}).(**DiscoveryServer)
 	if !ok || dds == nil {
@@ -164,18 +164,18 @@ func SendReportToDiscoveryServer(ctx context.Context, report *messages.Report) {
 			}
 		}
 	}
-	for _, attmpt := range report.Attempts {
-		if attmpt.Request != nil {
-			if attmpt.Request.Header != nil {
+	for _, attempt := range report.Attempts {
+		if attempt.Request != nil {
+			if attempt.Request.Header != nil {
 				for _, header := range filter {
-					delete(attmpt.Request.Header, header)
+					delete(attempt.Request.Header, header)
 				}
 			}
 		}
-		if attmpt.Response != nil {
-			if attmpt.Response.Header != nil {
+		if attempt.Response != nil {
+			if attempt.Response.Header != nil {
 				for _, header := range filter {
-					delete(attmpt.Response.Header, header)
+					delete(attempt.Response.Header, header)
 				}
 			}
 		}

--- a/v2/pkg/output/json.go
+++ b/v2/pkg/output/json.go
@@ -22,7 +22,7 @@ func _json_handleEvent(o *output, e events.Event) {
 	humanOutput := o.Format == ""
 
 	_, includeFileContent := o.FormatOpts["include-file-contents"]
-	// if the user want to receive to stdout then the received content wont be saved to disk
+	// if the user want to receive to stdout then the received content won't be saved to disk
 	// so we include it in the json report which is going to stdout
 	if _, exclude := o.FormatOpts["exclude-file-contents"]; exclude {
 		includeFileContent = false
@@ -30,7 +30,7 @@ func _json_handleEvent(o *output, e events.Event) {
 
 	switch event := e.(type) {
 	case events.ClientDisconnected:
-		// if an error occured, then set the error message
+		// if an error occurred, then set the error message
 		if err := event.Err; err != nil {
 			o.currentClientSession.Error = err.Error()
 		}
@@ -130,7 +130,7 @@ func _json_handleContextDone(ctx context.Context, o *output) {
 		if o.currentClientSession != nil {
 			// and the client session has already reported a request
 			if o.currentClientSession.Request != nil {
-				// then read in the body since it wasnt written to disk
+				// then read in the body since it wasn't written to disk
 				if err := o.currentClientSession.Request.ReadBody(); err != nil {
 					log.Error().Err(err).
 						Msg("error reading request body buffer")
@@ -139,7 +139,7 @@ func _json_handleContextDone(ctx context.Context, o *output) {
 		}
 	} else if o.currentClientSession != nil {
 		if o.currentClientSession.Request != nil {
-			// otherwise, theres no point in showing the content again in stdout
+			// otherwise, there's no point in showing the content again in stdout
 			o.currentClientSession.Request.Body = nil
 		}
 	}
@@ -162,14 +162,14 @@ func _json_handleContextDone(ctx context.Context, o *output) {
 		// if serving to stdout
 		if o.includeBody {
 			if s.Request != nil {
-				// then read in the body since it wasnt written to disk
+				// then read in the body since it wasn't written to disk
 				if err := s.Request.ReadBody(); err != nil {
 					log.Error().Err(err).
 						Msg("error reading request body buffer")
 				}
 			}
 		} else {
-			// otherwise, theres no point in showing the content again in stdout
+			// otherwise, there's no point in showing the content again in stdout
 			s.Request.Body = nil
 		}
 


### PR DESCRIPTION
Found via `codespell -H -S .git,*.svg -L te,ptd,preject,fo,nd,ans`